### PR TITLE
ci: trunk-based cleanup (drop develop, plain release tags)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main]
   pull_request:
 
 jobs:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,7 @@
     ".": {
       "release-type": "node",
       "changelog-path": "CHANGELOG.md",
+      "include-component-in-tag": false,
       "bump-minor-pre-major": false,
       "bump-patch-for-minor-pre-major": false,
       "draft": false,


### PR DESCRIPTION
ci: drop develop from push triggers (trunk-based on main)

Moving to a trunk-based flow with main as the single integration branch; develop is being retired. PRs still run via the pull_request trigger.