### PR TITLE
fix: force release-please boundary at v1.3.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,6 +5,7 @@
       "release-type": "node",
       "changelog-path": "CHANGELOG.md",
       "include-component-in-tag": false,
+      "last-release-sha": "59fdbe90e0d0ba5d110317fab1f5cba03c29fadc",
       "bump-minor-pre-major": false,
       "bump-patch-for-minor-pre-major": false,
       "draft": false,


### PR DESCRIPTION
fix: pin release-please last-release-sha to v1.3.0 commit

The tag-format switch (include-component-in-tag) broke release-please's release discovery, so it re-scanned the full history and proposed a bogus 1.4.0. Pin last-release-sha to the v1.3.0 release commit to force the commit-scan boundary; only post-1.3.0 commits are considered.