### PR TITLE
chore: unpin release-please last-release-sha 

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,6 @@
       "release-type": "node",
       "changelog-path": "CHANGELOG.md",
       "include-component-in-tag": false,
-      "last-release-sha": "59fdbe90e0d0ba5d110317fab1f5cba03c29fadc",
       "bump-minor-pre-major": false,
       "bump-patch-for-minor-pre-major": false,
       "draft": false,


### PR DESCRIPTION
chore: remove pinned last-release-sha

The pin was a one-shot to clear the bogus 1.4.0 release PR. Removing it so future releases use normal tag/release discovery (the plain v1.3.0 GitHub Release now exists as the boundary); leaving it pinned would re-scan from 1.3.0 every release.