### PR TITLE
feat(errors): export error classes and return 404 for missing config

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Examples:
 - [Plugin Options](#plugin-options)
 - [Plugin Decorators](#plugin-decorators)
 - [Route Options](#route-options)
+- [Error Handling](#error-handling)
 - [TypeScript: Declaration Merging](#typescript-declaration-merging)
 - [Advanced: Tenant Resources Context](#advanced-tenant-resources-context)
 - [Performance Considerations](#performance-considerations)
@@ -344,6 +345,42 @@ The `identifierStrategy` option allows you to specify a custom tenant identifica
             }
         },
 ```
+
+## Error Handling
+
+The plugin throws typed errors during tenant identification and resource resolution. They are exported
+so you can `instanceof`-check them in a `setErrorHandler` and map them to your own response shape.
+Each error carries a numeric `statusCode`.
+
+| Class | `statusCode` | Thrown when |
+|-------|--------------|-------------|
+| `TenantRequiredError` | `400` | No strategy returned a tenant id (missing/empty). |
+| `TenantConfigurationNotFound` | `404` | `tenantConfigResolver` returned `undefined` for the tenant. |
+| `TenantResourcesNotFound` | `500` | Config resolved but resources resolved to `undefined`. |
+| `TenantResourceCreateError` | `500` | A resource factory threw while creating resources. |
+
+```ts
+import {
+  TenantRequiredError,
+  TenantConfigurationNotFound,
+} from '@giogaspa/fastify-multitenant'
+
+fastify.setErrorHandler((error, request, reply) => {
+  if (error instanceof TenantRequiredError) {
+    return reply.status(400).send({ error: 'tenant_required' })
+  }
+
+  if (error instanceof TenantConfigurationNotFound) {
+    return reply.status(404).send({ error: 'tenant_not_found' })
+  }
+
+  // Fall back to the error's own statusCode.
+  return reply.status(error.statusCode ?? 500).send({ error: 'internal_error' })
+})
+```
+
+> ⚠️ Avoid echoing the tenant id back to the client — the built-in messages include it for
+> server-side logging, so return a generic client-facing message as shown above.
 
 ## TypeScript: Declaration Merging
 

--- a/playground/src/app.ts
+++ b/playground/src/app.ts
@@ -1,5 +1,5 @@
 import { FastifyInstance, FastifyPluginAsync } from 'fastify'
-import fastifyMultitenant, { headerIdentifierStrategy, FastifyMultitenantOptions, queryIdentifierStrategy, createTenantResourceConfig } from '@giogaspa/fastify-multitenant'
+import fastifyMultitenant, { headerIdentifierStrategy, FastifyMultitenantOptions, queryIdentifierStrategy, createTenantResourceConfig, TenantRequiredError, TenantConfigurationNotFound } from '@giogaspa/fastify-multitenant'
 import { eq } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/libsql'
 import { createClient } from '@libsql/client';
@@ -77,6 +77,20 @@ export const app: FastifyPluginAsync = async function App(server: FastifyInstanc
 
     // Register plugins
     server.register(fastifyMultitenant, options)
+
+    // Map plugin errors to client-facing responses (do not echo the tenant id back)
+    server.setErrorHandler((error, request, reply) => {
+        if (error instanceof TenantRequiredError) {
+            return reply.status(400).send({ error: 'tenant_required' })
+        }
+
+        if (error instanceof TenantConfigurationNotFound) {
+            return reply.status(404).send({ error: 'tenant_not_found' })
+        }
+
+        request.log.error(error)
+        return reply.status(error.statusCode ?? 500).send({ error: 'internal_error' })
+    })
 
     // Register modules
     server.register(GreetingModule)

--- a/src/errors/TenantConfigurationError.ts
+++ b/src/errors/TenantConfigurationError.ts
@@ -1,9 +1,0 @@
-export class TenantConfigurationError extends Error {
-    statusCode: number
-    
-    constructor(message = 'Tenant configuration error') {
-        super(message)
-        this.name = 'TenantConfigurationError'
-        this.statusCode = 500
-    }
-}

--- a/src/errors/TenantConfigurationNotFound.ts
+++ b/src/errors/TenantConfigurationNotFound.ts
@@ -6,6 +6,6 @@ export class TenantConfigurationNotFound extends Error {
     constructor(tenantId: TenantId) {
         super(`[${tenantId}] Tenant configuration not found. Please check if the tenant exists and is properly configured.`)
         this.name = 'TenantConfigurationNotFound'
-        this.statusCode = 401
+        this.statusCode = 404
     }
 }

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,0 +1,4 @@
+export { TenantRequiredError } from './TenantRequiredError.js'
+export { TenantConfigurationNotFound } from './TenantConfigurationNotFound.js'
+export { TenantResourcesNotFound } from './TenantResourcesNotFound.js'
+export { TenantResourceCreateError } from './TenantResourceCreateError.js'

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,10 +2,7 @@ import { FastifyInstance, FastifyReply, FastifyRequest, HookHandlerDoneFunction 
 import fp from 'fastify-plugin'
 
 import { BaseTenantConfig, BaseTenantResources, FastifyMultitenantOptions, FastifyMultitenantRouteOptions, IdentifierStrategy, TenantConfigProvider, TenantResourcesProvider } from './types.js'
-import { TenantRequiredError } from './errors/TenantRequiredError.js'
-import { TenantConfigurationNotFound } from './errors/TenantConfigurationNotFound.js'
-import { TenantResourcesNotFound } from './errors/TenantResourcesNotFound.js'
-import { TenantResourceCreateError } from './errors/TenantResourceCreateError.js'
+import { TenantRequiredError, TenantConfigurationNotFound, TenantResourcesNotFound, TenantResourceCreateError } from './errors/index.js'
 import { tenantConfigProviderFactory } from './providers/tenant-config-provider.js'
 import { tenantResourceProviderFactory } from './providers/tenant-resource-provider.js'
 import { identifyTenantFactory } from './tenant-identification.js'
@@ -17,6 +14,7 @@ export { headerIdentifierStrategy } from './strategies/header-identifier-strateg
 export { queryIdentifierStrategy } from './strategies/query-identifier-strategy.js'
 export { tenantResourcesContext } from './request-context.js'
 export { createTenantResourceConfig, CreateTenantResourceConfigArgs } from './utils.js'
+export { TenantRequiredError, TenantConfigurationNotFound, TenantResourcesNotFound, TenantResourceCreateError } from './errors/index.js'
 
 declare module "fastify" {
     interface FastifyInstance {


### PR DESCRIPTION
feat(errors): export error classes and return 404 for missing config

Export TenantRequiredError, TenantConfigurationNotFound, TenantResourcesNotFound and TenantResourceCreateError from the package entry via an errors/ barrel, so consumers can instanceof-check them in a setErrorHandler. Drop the unused TenantConfigurationError (never thrown). Document an Error Handling recipe in the README and the playground.

TenantConfigurationNotFound now responds 404 instead of 401, which was semantically wrong (Unauthorized) for an unknown tenant.