### PR TITLE
chore(playground): fix exclude route config key

### DIFF
--- a/playground/src/app.ts
+++ b/playground/src/app.ts
@@ -101,7 +101,7 @@ export const app: FastifyPluginAsync = async function App(server: FastifyInstanc
         '/no-tenant',
         {
             config: {
-                fastifyMultitenant: {
+                multitenant: {
                     exclude: true
                 }
             }
@@ -115,7 +115,7 @@ export const app: FastifyPluginAsync = async function App(server: FastifyInstanc
         '/invalidate-all',
         {
             config: {
-                fastifyMultitenant: {
+                multitenant: {
                     exclude: true
                 }
             }


### PR DESCRIPTION
Route config used the 'fastifyMultitenant' key, but the plugin reads 'config.multitenant.exclude'. The /no-tenant and /invalidate-all routes were therefore not excluded and failed tenant identification.