### PR TITLE
fix(identification): reject and trim whitespace-only tenant ids

### DIFF
--- a/src/normalize-tenant-id.ts
+++ b/src/normalize-tenant-id.ts
@@ -1,0 +1,17 @@
+import { TenantId } from "./types.js"
+
+/**
+ * Normalizes a raw value returned by an identifier strategy into a tenant id.
+ * Returns `undefined` for non-string or whitespace-only values, otherwise the trimmed string.
+ *
+ * @param value The raw value produced by a strategy (header/query value, custom strategy result, ...).
+ */
+export function normalizeTenantId(value: unknown): TenantId | undefined {
+    if (typeof value !== 'string') {
+        return undefined
+    }
+
+    const trimmed = value.trim()
+
+    return trimmed.length === 0 ? undefined : trimmed
+}

--- a/src/strategies/header-identifier-strategy.ts
+++ b/src/strategies/header-identifier-strategy.ts
@@ -3,13 +3,15 @@ import { FastifyRequest } from "fastify"
 import { IdentifierStrategyFactory } from "./types.js"
 
 export const headerIdentifierStrategy: IdentifierStrategyFactory = (name: string) => {
-    return (request: FastifyRequest) => {
-        const headerValue = request.headers[name.toLowerCase()]
+    const lowerCaseName = name.toLowerCase()
 
-        if (headerValue) {
-            return headerValue as string | undefined
+    return (request: FastifyRequest) => {
+        const headerValue = request.headers[lowerCaseName]
+
+        if (typeof headerValue !== "string") {
+            return undefined
         }
 
-        return undefined
+        return headerValue
     }
 }

--- a/src/strategies/query-identifier-strategy.ts
+++ b/src/strategies/query-identifier-strategy.ts
@@ -4,19 +4,18 @@ import { IdentifierStrategyFactory } from "./types.js"
 
 export const queryIdentifierStrategy: IdentifierStrategyFactory = (paramName: string) => {
     return (request: FastifyRequest) => {
-        //request.log.debug("Run queryIdentifierStrategy")
-
         const { query } = request as { query?: Record<string, unknown> }
 
-        if (
-            !query
-            || typeof query !== 'object'
-            || !(paramName in query)
-            || query[paramName] === ''
-        ) {
+        if (!query) {
             return undefined
         }
 
-        return query[paramName] as string | undefined
+        const paramValue = query[paramName]
+
+        if (typeof paramValue !== 'string') {
+            return undefined
+        }
+
+        return paramValue
     }
 }

--- a/src/tenant-identification.ts
+++ b/src/tenant-identification.ts
@@ -1,6 +1,7 @@
 import { FastifyRequest } from "fastify"
 
 import { TenantId, IdentifierStrategy } from "./types.js"
+import { normalizeTenantId } from "./normalize-tenant-id.js"
 
 export function identifyTenantFactory(strategies: IdentifierStrategy[]) {
     if (!strategies || strategies.length === 0) {
@@ -11,7 +12,9 @@ export function identifyTenantFactory(strategies: IdentifierStrategy[]) {
         let tenantId: TenantId | undefined = undefined
 
         for (const strategyFn of strategies) {
-            tenantId = await strategyFn(request)
+            // Normalize every strategy's result here so all strategies — built-in and custom —
+            // get the same trim/reject-empty handling, and a whitespace-only id falls through.
+            tenantId = normalizeTenantId(await strategyFn(request))
             if (tenantId) {
                 break // Exit the loop if a tenant ID is found
             }

--- a/test/identification.test.ts
+++ b/test/identification.test.ts
@@ -1,0 +1,66 @@
+'use strict'
+
+import assert from "node:assert"
+import test from "node:test"
+import { FastifyRequest } from "fastify"
+
+import { identifyTenantFactory } from "../src/tenant-identification.js"
+import { headerIdentifierStrategy } from "../src/strategies/header-identifier-strategy.js"
+import { queryIdentifierStrategy } from "../src/strategies/query-identifier-strategy.js"
+
+const request = {} as FastifyRequest
+
+test('Custom strategy: tenant id is trimmed', async () => {
+    const identify = identifyTenantFactory([() => '  acme  '])
+
+    const tenantId = await identify(request)
+
+    assert.strictEqual(tenantId, 'acme', 'Should trim the id returned by a custom strategy')
+})
+
+test('Custom strategy: whitespace-only id falls through to the next strategy', async () => {
+    const identify = identifyTenantFactory([
+        () => '   ',
+        () => 'fallback',
+    ])
+
+    const tenantId = await identify(request)
+
+    assert.strictEqual(tenantId, 'fallback', 'A whitespace-only id should not win; the next strategy should be tried')
+})
+
+test('Custom strategy: whitespace-only id with no fallback resolves to undefined', async () => {
+    const identify = identifyTenantFactory([() => '   '])
+
+    const tenantId = await identify(request)
+
+    assert.strictEqual(tenantId, undefined, 'A whitespace-only id should resolve to undefined')
+})
+
+test('Header strategy through the pipeline: empty / whitespace value resolves to undefined', async () => {
+    const TENANT_HEADER = 'x-tenant-id'
+    const identify = identifyTenantFactory([headerIdentifierStrategy(TENANT_HEADER)])
+
+    const empty = await identify({ headers: { [TENANT_HEADER]: '' } } as any)
+    assert.strictEqual(empty, undefined, 'Empty header value should resolve to undefined')
+
+    const whitespace = await identify({ headers: { [TENANT_HEADER]: '   ' } } as any)
+    assert.strictEqual(whitespace, undefined, 'Whitespace-only header value should resolve to undefined')
+
+    const padded = await identify({ headers: { [TENANT_HEADER]: '  tenant1  ' } } as any)
+    assert.strictEqual(padded, 'tenant1', 'A padded header value should be trimmed')
+})
+
+test('Query strategy through the pipeline: empty / whitespace value resolves to undefined', async () => {
+    const TENANT_PARAM = 'tenantId'
+    const identify = identifyTenantFactory([queryIdentifierStrategy(TENANT_PARAM)])
+
+    const empty = await identify({ query: { [TENANT_PARAM]: '' } } as any)
+    assert.strictEqual(empty, undefined, 'Empty query value should resolve to undefined')
+
+    const whitespace = await identify({ query: { [TENANT_PARAM]: '   ' } } as any)
+    assert.strictEqual(whitespace, undefined, 'Whitespace-only query value should resolve to undefined')
+
+    const padded = await identify({ query: { [TENANT_PARAM]: '  tenant1  ' } } as any)
+    assert.strictEqual(padded, 'tenant1', 'A padded query value should be trimmed')
+})

--- a/test/strategies.test.ts
+++ b/test/strategies.test.ts
@@ -38,20 +38,20 @@ test('Header strategy - missing header', async () => {
     assert.strictEqual(resolvedTenantId, undefined, 'Should return undefined if the header is missing')
 })
 
-test('Header strategy - empty header value', async () => {
+test('Header strategy - array header value', async () => {
     const TENANT_HEADER = 'x-tenant-id'
 
     const strategy = headerIdentifierStrategy(TENANT_HEADER)
 
     const request: FastifyRequest = {
         headers: {
-            [TENANT_HEADER]: ''
+            [TENANT_HEADER]: ['tenant1', 'tenant2']
         }
     } as any
 
     const resolvedTenantId = strategy(request)
 
-    assert.strictEqual(resolvedTenantId, undefined, 'Should return undefined when header value is empty')
+    assert.strictEqual(resolvedTenantId, undefined, 'Should return undefined for a non-string (array) header value')
 })
 
 test('Query strategy', async () => {
@@ -85,18 +85,18 @@ test('Query strategy - missing parameter', async () => {
     assert.strictEqual(resolvedTenantId, undefined, 'Should return undefined if the query parameter is missing')
 })
 
-test('Query strategy - empty parameter value', async () => {
+test('Query strategy - array parameter value', async () => {
     const TENANT_PARAM = 'tenantId'
 
     const strategy = queryIdentifierStrategy(TENANT_PARAM)
 
     const request: FastifyRequest = {
         query: {
-            [TENANT_PARAM]: ''
+            [TENANT_PARAM]: ['tenant1', 'tenant2']
         }
     } as any
 
     const resolvedTenantId = strategy(request)
 
-    assert.strictEqual(resolvedTenantId, undefined, 'Should return undefined when query parameter value is empty')
+    assert.strictEqual(resolvedTenantId, undefined, 'Should return undefined for a non-string (array) query parameter value')
 })


### PR DESCRIPTION
Normalize every strategy's result in identifyTenantFactory via a shared normalizeTenantId helper (non-string -> undefined; trim; reject empty), so built-in, custom and future strategies all get the same handling and a whitespace-only id falls through to the next strategy. Built-in strategies now only narrow their raw value to string | undefined.