### PR TITLE
fix: clean up tenant resources on shutdown and harden teardown

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Examples:
 - 🔍 **Composable tenant detection** via identifier strategies (e.g., `headerIdentifierStrategy`, `queryIdentifierStrategy`,...)
 - 🧩 **Register tenant-specific resources** (DB, Mailer, OpenAI, in-memory stores, etc.)
 - 🔁 **Access other tenant resources inside a resource factory**
+- 🧹 **Automatic resource cleanup on server shutdown** (runs each resource's `onDelete`)
 - ✨ Written in **TypeScript** with full type safety and autocompletion
 
 ### In progress

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ const DEFAULT_TENANT_IDENTIFICATION_HOOK = 'onRequest'
 async function fastifyMultitenant<TenantConfig extends BaseTenantConfig, TenantResources extends BaseTenantResources>(fastify: FastifyInstance, opts: FastifyMultitenantOptions<TenantConfig, TenantResources>) {
     const globalIdentifyTenant = identifyTenantFactory(opts.tenantIdentifierStrategies)
     const configProvider = tenantConfigProviderFactory<TenantConfig>(opts.tenantConfigResolver)
-    const resourceProvider = tenantResourceProviderFactory<TenantConfig, TenantResources>(opts.resources, configProvider)
+    const resourceProvider = tenantResourceProviderFactory<TenantConfig, TenantResources>(opts.resources, configProvider, fastify.log)
     const hook = opts.hook || DEFAULT_TENANT_IDENTIFICATION_HOOK
 
     fastify.decorate(
@@ -48,6 +48,12 @@ async function fastifyMultitenant<TenantConfig extends BaseTenantConfig, TenantR
     // `FastifyRequest`, and the `null as any` cast initializes the decorator without clashing with
     // whatever (possibly non-null) type the consumer declares for `tenant`.
     fastify.decorateRequest('tenant', null as any)
+
+    // Release every tenant's cached resources on server shutdown, running each resource's
+    // onDelete hook (e.g. closing DB connections) so they don't leak when the server stops.
+    fastify.addHook('onClose', async () => {
+        await resourceProvider.invalidateAll()
+    })
 
     fastify.addHook(hook, function (this: FastifyInstance, request: FastifyRequest, reply: FastifyReply, done: HookHandlerDoneFunction) {
         if (isExcludedRoute(request)) {

--- a/src/providers/tenant-resource-provider.ts
+++ b/src/providers/tenant-resource-provider.ts
@@ -1,14 +1,18 @@
-import { BaseTenantConfig, TenantId, TenantResourceConfigs, TenantResourcesProvider, BaseTenantResources, TenantConfigProvider } from "../types.js"
+import { FastifyBaseLogger } from "fastify"
+
+import { BaseTenantConfig, TenantId, TenantResourceConfigs, TenantResourcesProvider, BaseTenantResources, TenantConfigProvider, TenantResourceConfig, TenantResourceOnDeleteHook } from "../types.js"
 
 /**
- * 
+ *
  * @param resourceConfigs Tenant resource
- * @param configProvider 
- * @returns 
+ * @param configProvider
+ * @param logger Optional logger used to report errors.
+ * @returns
  */
 export function tenantResourceProviderFactory<TenantConfig extends BaseTenantConfig, TenantResources extends BaseTenantResources>(
     resourceConfigs: TenantResourceConfigs<TenantConfig, TenantResources>,
-    configProvider: TenantConfigProvider<TenantConfig>
+    configProvider: TenantConfigProvider<TenantConfig>,
+    logger?: FastifyBaseLogger
 ): TenantResourcesProvider<TenantResources> {
     const inMemoryResourcesCache = new Map<TenantId, Promise<TenantResources | undefined>>()
 
@@ -34,18 +38,43 @@ export function tenantResourceProviderFactory<TenantConfig extends BaseTenantCon
      * @param tenantId - The ID of the tenant whose resources should be invalidated.
      */
     async function invalidate(tenantId: TenantId) {
-        if (inMemoryResourcesCache.has(tenantId)) {
-            const tenantResources = inMemoryResourcesCache.get(tenantId)
+        if (!inMemoryResourcesCache.has(tenantId)) {
+            logger?.debug({ tenantId }, `No cached resources found for tenant ${tenantId}. Nothing to invalidate.`)
+            return
+        }
 
-            for (const [name, resource] of Object.entries(tenantResources!)) {
-                const config = resourceConfigs[name]
+        try {
+            // The cache stores the resource-creation promise; await it before iterating.
+            const tenantResourcesPromise = inMemoryResourcesCache.get(tenantId)
 
-                if (typeof config === 'object' && 'onDelete' in config && typeof config.onDelete === 'function') {
-                    await config.onDelete(resource)
+            // Remove the tenant's resources from the cache before awaiting, so a concurrent getAll
+            // rebuilds a fresh resource instead of receiving the one being torn down (evict-first).
+            inMemoryResourcesCache.delete(tenantId)
+
+            const tenantResources = await tenantResourcesPromise
+
+            if (tenantResources) {
+                // Reverse the order of the resources to ensure that the onDelete hooks are called in the reverse order of creation
+                const resources = Object.entries(tenantResources).reverse()
+
+                // Run the onDelete hooks for each resource if they are defined
+                for (const [name, resource] of resources) {
+                    const config = resourceConfigs[name]
+
+                    if (hasOnDeleteHook(config)) {
+                        try {
+                            await config.onDelete(resource)
+                        } catch (err) {
+                            // Best-effort cleanup: log and keep tearing down the remaining resources.
+                            logger?.error({ err, tenantId, resource: name }, `Tenant resource ${name} onDelete hook failed for tenant ${tenantId}`)
+                        }
+                    }
                 }
             }
-
-            inMemoryResourcesCache.delete(tenantId)
+        } catch (err) {
+            // Resource creation failed earlier (a rejected promise is cached): there is nothing
+            // to tear down — the poisoned entry has already been evicted above.
+            logger?.debug({ err, tenantId }, `Invalidating a tenant ${tenantId} whose resource creation had failed.`)
         }
     }
 
@@ -56,9 +85,8 @@ export function tenantResourceProviderFactory<TenantConfig extends BaseTenantCon
      * This is useful when you want to ensure that all resources are recreated on the next request
      */
     async function invalidateAll() {
-        for (const [tenantId] of inMemoryResourcesCache.entries()) {
-            await invalidate(tenantId)
-        }
+        const tenantIds = Array.from(inMemoryResourcesCache.keys())
+        await Promise.allSettled(tenantIds.map(invalidate))
 
         inMemoryResourcesCache.clear()
     }
@@ -87,6 +115,13 @@ export function tenantResourceProviderFactory<TenantConfig extends BaseTenantCon
         }
 
         return resources as TenantResources
+    }
+
+    function hasOnDeleteHook(config: TenantResourceConfig<TenantConfig, TenantResources, any>): config is TenantResourceConfig<TenantConfig, TenantResources, any> & { onDelete: TenantResourceOnDeleteHook<any> } {
+        return config
+            && typeof config === 'object'
+            && 'onDelete' in config
+            && typeof config.onDelete === 'function'
     }
 
     return {

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -254,3 +254,184 @@ test('Custom route tenant identification strategy', async () => {
         'tenant2',
     );
 })
+
+test('Closing the server runs resource onDelete hooks (onClose cleanup)', async () => {
+    const app = fastify({ logger: false })
+
+    const deleted: string[] = []
+
+    const options: FastifyMultitenantOptions<TenantConfig, TenantResources> = {
+        tenantIdentifierStrategies: [headerIdentifierStrategy('X-TENANT-ID')],
+        tenantConfigResolver: async (tenantId: string) => ({ id: tenantId, name: `Tenant ${tenantId}`, greetings: [] }),
+        resources: {
+            ...createTenantResourceConfig<TenantConfig, TenantResources>({
+                name: 'id',
+                factory: async ({ tenantConfig }) => tenantConfig.id,
+                onDelete: async (resource) => {
+                    deleted.push(resource as string)
+                },
+            }),
+        },
+    }
+
+    await app.register(fastifyMultitenant, options)
+    app.get('/', async () => 'ok')
+    await app.ready()
+
+    // Create the tenant resources by serving a request for the tenant
+    await app.inject({ method: 'GET', url: '/', headers: { 'X-TENANT-ID': 'tenant1' } })
+
+    assert.deepEqual(deleted, [], 'onDelete should not run before the server is closed')
+
+    await app.close()
+
+    assert.deepEqual(deleted, ['tenant1'], 'onDelete should run for cached resources when the server closes')
+})
+
+test('Closing the server does not reject when a tenant resource failed to create', async () => {
+    const app = fastify({ logger: false })
+
+    const options: FastifyMultitenantOptions<TenantConfig, TenantResources> = {
+        tenantIdentifierStrategies: [headerIdentifierStrategy('X-TENANT-ID')],
+        tenantConfigResolver: async (tenantId: string) => ({ id: tenantId, name: `Tenant ${tenantId}`, greetings: [] }),
+        resources: {
+            ...createTenantResourceConfig<TenantConfig, TenantResources>({
+                name: 'id',
+                factory: async () => {
+                    throw new Error('resource creation failed')
+                },
+            }),
+        },
+    }
+
+    await app.register(fastifyMultitenant, options)
+    app.get('/', async () => 'ok')
+    await app.ready()
+
+    // The failed factory leaves a rejected creation promise cached for the tenant
+    const res = await app.inject({ method: 'GET', url: '/', headers: { 'X-TENANT-ID': 'tenant1' } })
+    assert.equal(res.statusCode, 500, 'the failed resource creation should surface as a 500')
+
+    // onClose -> invalidateAll must not re-throw the cached rejected creation promise
+    await assert.doesNotReject(app.close(), 'closing must not reject when a tenant resource failed to create')
+})
+
+test('Invalidate does not re-throw a cached failed-creation promise', async () => {
+    const app = fastify({ logger: false })
+
+    const options: FastifyMultitenantOptions<TenantConfig, TenantResources> = {
+        tenantIdentifierStrategies: [headerIdentifierStrategy('X-TENANT-ID')],
+        tenantConfigResolver: async (tenantId: string) => ({ id: tenantId, name: `Tenant ${tenantId}`, greetings: [] }),
+        resources: {
+            ...createTenantResourceConfig<TenantConfig, TenantResources>({
+                name: 'id',
+                factory: async () => {
+                    throw new Error('resource creation failed')
+                },
+            }),
+        },
+    }
+
+    await app.register(fastifyMultitenant, options)
+    app.get('/', async () => 'ok')
+    await app.ready()
+
+    // The failed factory leaves a rejected creation promise cached for the tenant
+    await app.inject({ method: 'GET', url: '/', headers: { 'X-TENANT-ID': 'tenant1' } })
+
+    // invalidate() must swallow the rejected creation promise (nothing to tear down) and evict
+    // the poisoned entry, not re-throw the original factory error.
+    await assert.doesNotReject(
+        app.multitenant.resourceProvider.invalidate('tenant1'),
+        'invalidate must not re-throw a cached failed-creation promise'
+    )
+
+    await app.close()
+})
+
+test('Invalidate runs the remaining onDelete hooks even if one throws', async () => {
+    const app = fastify({ logger: false })
+
+    const deleted: string[] = []
+
+    const options: FastifyMultitenantOptions<TenantConfig, TenantResources> = {
+        tenantIdentifierStrategies: [headerIdentifierStrategy('X-TENANT-ID')],
+        tenantConfigResolver: async (tenantId: string) => ({ id: tenantId, name: `Tenant ${tenantId}`, greetings: [] }),
+        resources: {
+            // Declared first -> torn down LAST (reverse order). It must still run even though the
+            // resource torn down before it (the thrower) throws.
+            ...createTenantResourceConfig<TenantConfig, TenantResources>({
+                name: 'survivor',
+                factory: async () => 'survivor-resource',
+                onDelete: async (resource) => {
+                    deleted.push(resource as string)
+                },
+            }),
+            // Declared last -> torn down FIRST. Its throw must not abort the survivor's onDelete.
+            ...createTenantResourceConfig<TenantConfig, TenantResources>({
+                name: 'thrower',
+                factory: async () => 'thrower-resource',
+                onDelete: async () => {
+                    throw new Error('thrower onDelete failed')
+                },
+            }),
+        },
+    }
+
+    await app.register(fastifyMultitenant, options)
+    app.get('/', async () => 'ok')
+    await app.ready()
+
+    await app.inject({ method: 'GET', url: '/', headers: { 'X-TENANT-ID': 'tenant1' } })
+
+    // A throwing onDelete (run first, due to reverse order) must not abort the cleanup of the
+    // tenant's other resources.
+    await assert.doesNotReject(
+        app.multitenant.resourceProvider.invalidate('tenant1'),
+        'invalidate must not reject when an onDelete throws'
+    )
+    assert.deepEqual(deleted, ['survivor-resource'], 'the sibling resource onDelete must still run after an earlier onDelete threw')
+
+    await app.close()
+})
+
+test('Invalidate runs onDelete hooks in reverse creation order', async () => {
+    const app = fastify({ logger: false })
+
+    const order: string[] = []
+
+    const options: FastifyMultitenantOptions<TenantConfig, TenantResources> = {
+        tenantIdentifierStrategies: [headerIdentifierStrategy('X-TENANT-ID')],
+        tenantConfigResolver: async (tenantId: string) => ({ id: tenantId, name: `Tenant ${tenantId}`, greetings: [] }),
+        resources: {
+            ...createTenantResourceConfig<TenantConfig, TenantResources>({
+                name: 'db',
+                factory: async () => 'db',
+                onDelete: async () => {
+                    order.push('db')
+                },
+            }),
+            ...createTenantResourceConfig<TenantConfig, TenantResources>({
+                name: 'mailer',
+                factory: async () => 'mailer',
+                onDelete: async () => {
+                    order.push('mailer')
+                },
+            }),
+        },
+    }
+
+    await app.register(fastifyMultitenant, options)
+    app.get('/', async () => 'ok')
+    await app.ready()
+
+    await app.inject({ method: 'GET', url: '/', headers: { 'X-TENANT-ID': 'tenant1' } })
+
+    await app.multitenant.resourceProvider.invalidate('tenant1')
+
+    // Resources are created in declaration order (db then mailer, mailer may depend on db),
+    // so teardown must run in reverse — dependents (mailer) before dependencies (db).
+    assert.deepEqual(order, ['mailer', 'db'], 'onDelete should run in reverse creation order')
+
+    await app.close()
+})


### PR DESCRIPTION
Add an onClose hook that releases every tenant's cached resources via invalidateAll. Harden invalidate: evict the cache entry before awaiting (so a concurrent getAll rebuilds a fresh resource instead of one being torn down), guard a cached rejected creation promise, run onDelete hooks in reverse creation order, and isolate each onDelete failure (log and continue). invalidateAll now tears tenants down in parallel via Promise.allSettled. Teardown failures are logged via the Fastify logger.